### PR TITLE
Remove fa patch 3197016

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,6 @@
           },
           "drupal/core": {
             "#2951547: Fix issue with layout overflow": "https://www.drupal.org/files/issues/2020-01-08/layout-builder-tray-size-2951547-42.patch"
-          },
-          "drupal/fontawesome": {
-            "3197016: Font Awesome creates advertising line on each saving in CKEditor": "https://www.drupal.org/files/issues/2021-06-09/3197016-remove-comment-from-icons.patch"
           }
         },
         "installer-paths": {

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -63,5 +63,5 @@
         "asuwebplatforms/webspark-module-webspark_ckeditor_plugins": "dev-master",
         "drupal/layout_builder_component_attributes": "^1.2"
     },
-    "version": "0.1.23"
+    "version": "0.1.24"
 }


### PR DESCRIPTION
This is breaking the installation. 

From Pantheon:

  - Applying patches for drupal/fontawesome
 https://www.drupal.org/files/issues/2021-06-09/3197016-remove-comment-from-icons.patch (3197016: Font Awesome creates advertising line on each saving in CKEditor)
 Could not apply patch! Skipping. The error was: Cannot apply patch https://www.drupal.org/files/issues/2021-06-09/3197016-remove-comment-from-icons.patch

  [Exception]                                                                                                                                                                             
  Cannot apply patch 3197016: Font Awesome creates advertising line on each saving in CKEditor (https://www.drupal.org/files/issues/2021-06-09/3197016-remove-comment-from-icons.patch)!  
Why is this error suddenly occurring?

Your "composer.json" file says to download the latest version of "drupal/fontawesome" and then apply this patch. A few days ago, a new version of Font Awesome module was released: https://www.drupal.org/project/fontawesome/releases/8.x-2.19
So, the problem stopping your upstream from working is that the patch no longer applies to the latest version of 8.x-2.x. From the release notes in the link above, it looks like 8.x-2.19 may include the fix that was in the patch.

How can you get the WebSpark 2 upstream working again? You will need to do one of these things:
·        Update the "composer.json" to remove the patch or find a new patch that works against the 8.x-2.19 version. (recommended)

·        Update Composer to require that exactly the 8.x-2.18 version or some other version where the patch applies is required.


Once one of those changes are made to the upstream, then site creation should work again.

Unfortunately, it is the responsibility of the upstream maintainer to make sure the upstream continues to work and resolve these issues. I hope your team who manages the Webspark 2 Upstream can get this fixed soon.




