### PR TITLE
WS2-1433: Opt in to the D7 method of deleting files and media

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -39,7 +39,14 @@ if (file_exists($local_settings)) {
 if (PHP_SAPI !== 'cli') {
   $settings['config_readonly'] = TRUE;
 }
+
 /**
  * Allow all configuration to be changed.
  */
 $settings['config_readonly_whitelist_patterns'] = ['*'];
+
+/**
+ * Allow files to be deleted from the file system, similar to Drupal 7.
+ * See: https://www.drupal.org/node/2891902
+ */
+$config['file.settings']['make_unused_managed_files_temporary'] = TRUE;


### PR DESCRIPTION
See: https://asudev.jira.com/browse/WS2-1433

With this, we will need to take care to add into the release notes verbiage about what this does, why it does it, and how users can revert to the D9 behavior by setting the value to `FALSE`. We also can recommend users to use the Audit Files module (the module noted in the Drupal article) to help them find and remove orphaned files.