### PR TITLE
Webspark release 2.10.1 - https://webservices.asu.edu/announcements

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -77,5 +77,5 @@
     "config": {
         "sort-packages": true
     },
-    "version": "2.10.0"
+    "version": "2.10.1"
 }

--- a/web/modules/webspark/webspark_blocks/webspark_blocks.install
+++ b/web/modules/webspark/webspark_blocks/webspark_blocks.install
@@ -51,6 +51,13 @@ function webspark_blocks_update_9005(&$sandbox) {
 }
 
 /**
+ * WS2-1704 - Add back blocks revert call
+ */
+function webspark_blocks_update_9012(&$sandbox) {
+  _webspark_blocks_revert_module_config();
+}
+
+/**
  * Update 'Show borders' field on cards paragraphs to ensure it has a default value.
  */
 function webspark_blocks_update_9017() {

--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -2,7 +2,7 @@ name: Webspark
 type: profile
 core_version_requirement: ^9.0
 description: 'ASU custom profile.'
-version: 2.10.0
+version: 2.10.1
 distribution:
   name: 'Webspark'
 install:


### PR DESCRIPTION
Fixes update path from older versions by reinstating webspark_blocks config revert update hook.