### PR TITLE
Webspark release 2.10.2 - https://webservices.asu.edu/announcements

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -77,5 +77,5 @@
     "config": {
         "sort-packages": true
     },
-    "version": "2.10.1"
+    "version": "2.10.2"
 }

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -233,12 +233,19 @@ class ComposerScripts {
     return '';
   }
 
+  /**
+   * Merge the upstream and custom patches into a single file.
+   *
+   * @param PreCommandRunEvent $event
+   *
+   * @return void
+   */
   public static function writeComposerPatchFile(PreCommandRunEvent $event) {
     $websparkPath = 'upstream-configuration/patches.webspark.json';
     $customPath = 'custom-dependencies/patches.custom.json';
     $websparkArray = json_decode(file_get_contents($websparkPath), true);
     $customArray = json_decode(file_get_contents($customPath), true);
-    $combinedArray['patches'] = $websparkArray + $customArray;
+    $combinedArray['patches'] = array_merge_recursive($websparkArray, $customArray);
     $combinedJson = json_encode($combinedArray);
 
     file_put_contents("composer.patches.json", $combinedJson . PHP_EOL);

--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -2,7 +2,7 @@ name: Webspark
 type: profile
 core_version_requirement: ^9.0
 description: 'ASU custom profile.'
-version: 2.10.1
+version: 2.10.2
 distribution:
   name: 'Webspark'
 install:


### PR DESCRIPTION
Resolves issue with new patch system. When the Webspark and Custom user patches were merged, if both sets had the same keys (e.g. both supplied `drupal/core` patches) then the Custom user patches would be overwritten. With this fix they will merge together, retaining patches from both parties.