### PR TITLE
WS2-2789: Edit webspark_update_9019

### DIFF
--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -362,7 +362,7 @@ function webspark_update_9019(&$sandbox) {
   $new_results = [];
   // Convert node_type to entity_bundle:node and add result to $new_results.
   foreach ($results as $result) {
-    $fixUp = _fix_serialized(str_replace('node_type', 'entity_bundle:node', $result->data));
+    $fixUp = _fix_serialized(preg_replace('/\bnode_type\b/', 'entity_bundle:node', $result->data));
     $new_results[$result->name] = ['name'=> $result->name, 'data' => $fixUp];
   }
   foreach ($new_results as $nr) {


### PR DESCRIPTION
### Description

This fixes an issue where webspark_update_9019 replaces all occurrences of 'node_type' with 'entity_bundle:node' in configurations but inadvertently changes 'not_node_type' as well. This solution adds word boundaries around 'node_type'.


### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2789)

### Checklist

- [x] Design updates match [Web Standards](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/) and [Unity Design System](https://unity.web.asu.edu)
- [x] Solution is documented on the Jira ticket
- [x] QA steps to verify have been included on the Jira ticket
- [x] No new PHP or JS errors
- [x] No accessibility issues are introduced with this update
- [x] Added/updated README.md files, if relevant
- [x] Confirm that any yaml files included have a matching update hook

